### PR TITLE
Change the way the Progress Tooltip is shown

### DIFF
--- a/dribbblish.js
+++ b/dribbblish.js
@@ -157,19 +157,6 @@ waitForElement([".Root__main-view .os-resize-observer-host"], ([resizeHost]) => 
         const newText = Spicetify.Player.formatTime(timeOverride || Spicetify.Player.getProgress()) + " / " + Spicetify.Player.formatTime(Spicetify.Player.getDuration());
         // To reduce DOM Updates when the Song is Paused
         if (tooltip.innerText != newText) tooltip.innerText = newText;
-
-        const tooltipWidth = tooltip.clientWidth;
-        const knobOffsets = progKnob.getBoundingClientRect();
-        const barOffsets = progBar.getBoundingClientRect();
-        const distFromLeft = knobOffsets.left + progKnob.clientWidth / 2 - barOffsets.left;
-        const distFromRight = Math.abs(knobOffsets.right - progKnob.clientWidth / 2 - barOffsets.right);
-        if (distFromLeft < tooltipWidth / 2 + 10) {
-            tooltip.style.setProperty("--padding-offset", `${tooltipWidth / 2 + 10 - distFromLeft}px`);
-        } else if (distFromRight < tooltipWidth / 2 + 10) {
-            tooltip.style.setProperty("--padding-offset", `-${tooltipWidth / 2 + 10 - distFromRight}px`);
-        } else {
-            tooltip.style.setProperty("--padding-offset", "0px");
-        }
     }
     const knobPosObserver = new MutationObserver((muts) => {
         const progressPercentage = Number(getComputedStyle(document.querySelector(".progress-bar")).getPropertyValue("--progress-bar-transform").replace("%", "")) / 100;

--- a/dribbblish.js
+++ b/dribbblish.js
@@ -153,8 +153,8 @@ waitForElement([".Root__main-view .os-resize-observer-host"], ([resizeHost]) => 
     tooltip.className = "prog-tooltip";
     progKnob.append(tooltip);
 
-    function updateProgTime() {
-        const newText = Spicetify.Player.formatTime(Spicetify.Player.getProgress()) + " / " + Spicetify.Player.formatTime(Spicetify.Player.getDuration());
+    function updateProgTime(timeOverride) {
+        const newText = Spicetify.Player.formatTime(timeOverride || Spicetify.Player.getProgress()) + " / " + Spicetify.Player.formatTime(Spicetify.Player.getDuration());
         // To reduce DOM Updates when the Song is Paused
         if (tooltip.innerText != newText) tooltip.innerText = newText;
 
@@ -172,7 +172,8 @@ waitForElement([".Root__main-view .os-resize-observer-host"], ([resizeHost]) => 
         }
     }
     const knobPosObserver = new MutationObserver((muts) => {
-        updateProgTime();
+        const progressPercentage = Number(getComputedStyle(document.querySelector(".progress-bar")).getPropertyValue("--progress-bar-transform").replace("%", "")) / 100;
+        updateProgTime(Spicetify.Player.getDuration() * progressPercentage);
     });
     knobPosObserver.observe(document.querySelector(".progress-bar"), {
         attributes: true,

--- a/user.css
+++ b/user.css
@@ -457,6 +457,9 @@ html.sidebar-hide-text .GlueDropTarget span {
     text-align: center;
     color: var(--spice-text);
     background-color: var(--spice-button);
+}
+
+.playback-bar:not(:active) .prog-tooltip {
     transition: transform 0.2s ease;
 }
 

--- a/user.css
+++ b/user.css
@@ -426,12 +426,38 @@ html.sidebar-hide-text .GlueDropTarget span {
     --bg-color: rgba(var(--spice-rgb-text), .2);
 }
 
+.progress-bar__slider {
+    display: block !important;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.progress-bar:hover .progress-bar__slider,
+.progress-bar:active .progress-bar__slider {
+    opacity: 1;
+}
+
 .progress-bar:not(:active) .x-progressBar-progressBarBg > div:first-child > div {
     transition: transform 0.2s ease;
 }
 
 .progress-bar:not(:active) .progress-bar__slider {
-    transition: left 0.2s ease;
+    transition-property: left,opacity;
+}
+
+.playback-bar .prog-tooltip {
+    --padding-offset: 0px;
+    position: absolute;
+    min-width: 100px;
+    top: -35px;
+    left: 50%;
+    transform: translateX(calc(-50% + var(--padding-offset)));
+    padding: 0 5px;
+    border-radius: 4px;
+    text-align: center;
+    color: var(--spice-text);
+    background-color: var(--spice-button);
+    transition: transform 0.2s ease;
 }
 
 .minimal-player .player-controls__buttons {
@@ -580,30 +606,6 @@ li.GlueDropTarget {
     border-radius: var(--main-corner-radius);
     z-index: 2;
     pointer-events: none;
-}
-
-.playback-bar .prog-tooltip {
-    position: absolute;
-    min-width: 100px;
-    width: unset;
-    height: 25px;
-    top: -35px;
-    padding: 0 5px;
-    border-radius: 4px;
-    text-align: center;
-    color: var(--spice-text);
-    background-color: var(--spice-button);
-    opacity: 0;
-    transition: opacity,left 0.2s ease;
-}
-
-.playback-bar:active .prog-tooltip {
-    opacity: 1;
-    transition: none;
-}
-
-.playback-bar:hover .prog-tooltip {
-    opacity: 1;
 }
 
 /** Rearrange player bar */

--- a/user.css
+++ b/user.css
@@ -5,6 +5,7 @@
     --main-corner-radius: 10px;
     --scrollbar-vertical-size: 8px;
     --cover-border-radius: 8px;
+    --playbar-movement-anim-speed: 0.5s;
     --os-windows-icon-dodge: 0;
 }
 
@@ -438,7 +439,7 @@ html.sidebar-hide-text .GlueDropTarget span {
 }
 
 .progress-bar:not(:active) .x-progressBar-progressBarBg > div:first-child > div {
-    transition: transform 0.2s ease;
+    transition: transform var(--playbar-movement-anim-speed) ease;
 }
 
 .progress-bar:not(:active) .progress-bar__slider {
@@ -446,12 +447,11 @@ html.sidebar-hide-text .GlueDropTarget span {
 }
 
 .playback-bar .prog-tooltip {
-    --padding-offset: 0px;
     position: absolute;
     min-width: 100px;
     top: -35px;
     left: 50%;
-    transform: translateX(calc(-50% + var(--padding-offset)));
+    transform: translateX(calc(-50%));
     padding: 0 5px;
     border-radius: 4px;
     text-align: center;
@@ -460,7 +460,7 @@ html.sidebar-hide-text .GlueDropTarget span {
 }
 
 .playback-bar:not(:active) .prog-tooltip {
-    transition: transform 0.2s ease;
+    transition: transform var(--playbar-movement-anim-speed) ease;
 }
 
 .minimal-player .player-controls__buttons {

--- a/user.css
+++ b/user.css
@@ -1,3 +1,8 @@
+/* Temporay fix for Canvas taking up half the screen */
+body > canvas[width="250"][height="250"] {
+    display: none;
+}
+
 :root {
     --bar-height: 70px;
     --bar-cover-art-size: 40px;


### PR DESCRIPTION
This PR changes `prog-tooltip.` to ba a child of `.progress-bar__slider`. This removes the need of setting its `left` property every few ms. My implimentation is probably not the best / efficient, and can be improved by a long shot.

At the moment there are a few bugs I cannot seem to figure out how to fix wich are basically all cases of the tooltip overflowing to the left on song change / first app start.

There is also a small problem with the constraining of the tooltip where it jitters slightly if the song plays and you hover the bar while the knob is on the left / right ends of the bar. this is fine to me but might not be for others.

**Also, as an explanation why i removed the `onprogress` event listener and added an `MutationObserver` and used `--progress-bar-transform` to calculate song progress:**
If you drag the knob, it will not fire an event. Only when you let the button go, so if you drag the knob, the tooltip's time won't get updated. So even though the Observer may be a little more inefficient, and calculating the time based on bar width might be 
 a little less precise, I personally prefer it because it keeps the time updated.


### This PR is more of a draft and as I said can be greatly improved, but as a first step I think this does the trick.