### PR TITLE
Small QoL Enhancements

### DIFF
--- a/dribbblish-dynamic.js
+++ b/dribbblish-dynamic.js
@@ -231,7 +231,7 @@ async function songchange() {
         album_date = album_date.toLocaleString('default', album_date>recent_date ? { year: 'numeric', month: 'short' } : { year: 'numeric' })
         album_link = "<a title=\""+Spicetify.Player.data.track.metadata.album_title+"\" href=\""+album_uri+"\" data-uri=\""+album_uri+"\" data-interaction-target=\"album-name\" class=\"tl-cell__content\">"+Spicetify.Player.data.track.metadata.album_title+"</a>"
         
-        nearArtistSpanText = album_link + " — " + album_date
+        nearArtistSpanText = album_link + " • " + album_date
     } else if (Spicetify.Player.data.track.uri.includes('spotify:episode')) {
         // podcast
         bgImage = bgImage.replace('spotify:image:', 'https://i.scdn.co/image/')

--- a/user.css
+++ b/user.css
@@ -249,6 +249,7 @@ span.artist-artistVerifiedBadge-badge svg > path:last-of-type {
 }
 
 .main-buddyFeed-activityMetadata .main-buddyFeed-artistAndTrackName a,
+.main-buddyFeed-activityMetadata .main-buddyFeed-artistAndTrackName span,
 .main-buddyFeed-activityMetadata .main-buddyFeed-playbackContextLink,
 .main-buddyFeed-activityMetadata .main-buddyFeed-timestamp {
     color: rgba(var(--spice-rgb-sidebar-text), 0.8);


### PR DESCRIPTION
- Change album / year divider from — to  •
  - The long dash can create confusion on japanese albums that have a similar character in them (used in japanese to express long vocals)
    - Example: https://open.spotify.com/album/129TFxq98ubI8cZfetjs3i?si=261e69f3fca542f8
      ![image](https://user-images.githubusercontent.com/24458276/135457150-a2fcfce3-8997-4894-8511-995cff83d23c.png)
  - This also adds consistency as the same dot separator is also used in Friend Activity to separate song name from artist
    ![image](https://user-images.githubusercontent.com/24458276/135455311-591f91df-361d-43cd-8e1b-676f1ea4a8c4.png)

- I've also added one selector to the css rule that makes friend activity text visible, now also the • is visible