### PR TITLE
Increase Opacity of Artist banner in light mode

### DIFF
--- a/user.css
+++ b/user.css
@@ -222,7 +222,7 @@ span.artist-artistVerifiedBadge-badge svg > path:last-of-type {
 
 /* Full window artist background */
 .main-entityHeader-background.main-entityHeader-gradient {
-    opacity: 0.3;
+    opacity: calc(0.3 + 0.3 * var(--is_light, 0));
 }
 
 .main-entityHeader-container.main-entityHeader-withBackgroundImage,


### PR DESCRIPTION
Closes #46 
So, I first thought it worked the other way around (that a solid color overlay was applied on the artist banner), that's the reason I mentioned decreasing the opacity of the overlay in the issue, but I think it looks better to actually increase the opacity of the banner image so it stands out more in light mode.
I've been testing this a bit and doesn't seem to affect readability too much.

**Comparison images:**
![image](https://user-images.githubusercontent.com/24458276/136653915-b078b630-ad48-4c00-8b65-64baceba6720.png)
![image](https://user-images.githubusercontent.com/24458276/136653957-62c35e53-3d70-436c-b16e-7096ddac3410.png)
Note: I think in dark mode the overlay opacity looks fine already so i left it at 0.3