### PR TITLE
Update manifest preview gif

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Dribbblish Dynamic (Beta)",
     "description": "A mod of Dribbblish theme for Spicetify with support for light/dark modes and album art based colors. (Beta Release)",
     "branch": "release-beta",
-    "preview": "showcase-images/preview.gif",
+    "preview": "https://raw.githubusercontent.com/JulienMaille/dribbblish-dynamic-theme/main/showcase-images/preview.gif",
     "readme": "README.md",
     "usercss": "user.css",
     "schemes": "color.ini",


### PR DESCRIPTION
Should work with new changes to allow links, currently only did it for previews since that seems to be the only one with a demand for it.