### PR TITLE
Fix Genres string being bigger than album/artist

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1330,7 +1330,7 @@ canvas[width="250"][height="250"] {
 }
 
 // fix albumn name font size (#171)
-.main-trackInfo-release {
+.main-type-finale {
     font-size: 10px;
 }
 


### PR DESCRIPTION
That CSS selector was introduced to fix #171
The same issue occurs if you enable the Genres string under the album, 
this Pull request aims to fix that
I'm using a different class selector that seems be used in both the string and nowhere else:
![image](https://user-images.githubusercontent.com/24458276/164993282-e8670d55-3139-40b2-a6df-1cd51218cc3f.png)


Screenshots before and after applying the patch:
![image](https://user-images.githubusercontent.com/24458276/164993241-753a09c6-6fa1-43bf-82fb-ddc7b5818e19.png)
![image](https://user-images.githubusercontent.com/24458276/164993236-a2ae5774-9d3d-4393-a726-8db82f108cf9.png)

_I know, pretty bad timing as you've just published a new release, but it's nothing too major, so it can be postponed until the next release_