### PR TITLE
chore: update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ assignees: ""
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. 
+1.
 
 **Screenshots**
 <!-- If applicable, add screenshots to help explain your problem. -->
@@ -26,7 +26,7 @@ Steps to reproduce the behavior:
 **Logs**
 <!--
     Add logs from console. To do that
-    1. Run `spicetify enable-devtool` in terminal
+    1. Run `spicetify enable-devtools` in terminal
     2. Spotify will be restarted
     3. Hit <kbd>Ctrl + Shift + I</kbd> to open DevTools window
     4. Navigate to tab Console


### PR DESCRIPTION
Very small update.
Spicetify recently changed their command to `enable-devtools` (with an `s`) (from spicetify/spicetify-cli#1613) and I figure to update this template with a more up-to-date guide