### PR TITLE
FIX: home page podcast episodes not showing

### DIFF
--- a/user.css
+++ b/user.css
@@ -991,9 +991,18 @@ img.main-devicePicker-nowPlayingActiveIcon,
     [style*="background-color"]:not(ul [style*="background-color"]):not(.main-shelf-shelfGrid [style*="background-color"]) {
         opacity: 0;
     }
+
     .main-entityHeader-container.main-entityHeader-withBackgroundImage {
         height: calc(20vh + 64px);
     }
+}
+
+/* Fixed invisible podcast in the home page */
+[class*="card-container"][style*="background-color"],
+[class*="card-container"] [style*="background-color"],
+[class*="shelfGrid"][style*="background-color"],
+[class*="shelfGrid"] [style*="background-color"] {
+    opacity: 1 !important;
 }
 
 /* Fix avatar icon */


### PR DESCRIPTION
Fixes an issue where podcast episodes and cards on the home page are invisible (but clickable) in dark modes. 

This happens because the theme's gradient-removal code accidentally hides them. The fix adds specific overrides for card and shelf containers to keep them visible while preserving the theme's default hover effects.
